### PR TITLE
refactor: migrate MangaLibraryJUnit to JUnit 5

### DIFF
--- a/MangaLibraryJUnit/pom.xml
+++ b/MangaLibraryJUnit/pom.xml
@@ -1,19 +1,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>java-codex-experience</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
     <groupId>com.exemplo.junit</groupId>
     <artifactId>MangaLibraryJUnit</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -22,11 +23,10 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
         </plugins>

--- a/MangaLibraryJUnit/src/test/java/com/exemplo/junit/AnimeTest.java
+++ b/MangaLibraryJUnit/src/test/java/com/exemplo/junit/AnimeTest.java
@@ -1,13 +1,16 @@
 package com.exemplo.junit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 
 public class AnimeTest {
-    @Test(expected = IllegalArgumentException.class)
-    public void testExcecaoAoCriarAnimeComAnoDeLancamentoInvalido() {
-        new Anime("Naruto", "Masashi Kishimoto", 2022, LocalDate.of(2002, 10, 3));
+    @Test
+    void testExcecaoAoCriarAnimeComAnoDeLancamentoInvalido() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                new Anime("Naruto", "Masashi Kishimoto", 2022, LocalDate.of(2002, 10, 3))
+        );
     }
 }
 

--- a/MangaLibraryJUnit/src/test/java/com/exemplo/junit/OtakuTest.java
+++ b/MangaLibraryJUnit/src/test/java/com/exemplo/junit/OtakuTest.java
@@ -1,13 +1,13 @@
 package com.exemplo.junit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 
 public class OtakuTest {
     @Test
-    public void testObterAnoDoAnimeMaisAntigo() {
+    void testObterAnoDoAnimeMaisAntigo() {
         Otaku leo = new Otaku("Leo");
         Anime anime1 = new Anime("Naruto", "Masashi Kishimoto", 2002, LocalDate.of(2002, 10, 3));
         Anime anime2 = new Anime("One Piece", "Eiichiro Oda", 1997, LocalDate.of(1997, 10, 20));
@@ -19,6 +19,6 @@ public class OtakuTest {
         leo.getcoletaneaDoOtaku().add(anime3);
         leo.getcoletaneaDoOtaku().add(anime4);
 
-        Assert.assertEquals(1984, leo.obterAnoDoAnimeMaisAntigo());
+        Assertions.assertEquals(1984, leo.obterAnoDoAnimeMaisAntigo());
     }
 }


### PR DESCRIPTION
## Summary
- replace JUnit 4 with JUnit Jupiter and inherit config from root pom
- add Maven Surefire plugin with module path disabled
- update tests to JUnit 5 assertions and API

## Testing
- `mvn -q -pl MangaLibraryJUnit test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc93dc30c832e8e7950097bdecc8c