### PR TITLE
Add exec-maven-plugin for AnimeRunner

### DIFF
--- a/MangaLibraryJUnit/pom.xml
+++ b/MangaLibraryJUnit/pom.xml
@@ -29,6 +29,14 @@
                     <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.exemplo.junit.AnimeRunner</mainClass>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Summary
- enable running AnimeRunner via `mvn exec:java` by adding `exec-maven-plugin`

## Testing
- `mvn -q -f MangaLibraryJUnit/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc9440834832ea098296a0f7a7982