### PR TITLE
Aceita percentual no aumento de salário

### DIFF
--- a/PooNoReinoAnimal/src/main/java/br/com/iniflex/FuncionarioService.java
+++ b/PooNoReinoAnimal/src/main/java/br/com/iniflex/FuncionarioService.java
@@ -28,7 +28,8 @@ public class FuncionarioService {
         lista.removeIf(f -> f.getNome().equalsIgnoreCase(nome));
     }
 
-    public void aplicarAumento(List<Funcionario> lista, BigDecimal fator) {
+    public void aplicarAumento(List<Funcionario> lista, BigDecimal percentual) {
+        BigDecimal fator = BigDecimal.ONE.add(percentual.movePointLeft(2));
         for (Funcionario f : lista) {
             f.setSalario(f.getSalario().multiply(fator).setScale(2, RoundingMode.HALF_UP));
         }

--- a/PooNoReinoAnimal/src/main/java/br/com/iniflex/Principal.java
+++ b/PooNoReinoAnimal/src/main/java/br/com/iniflex/Principal.java
@@ -37,6 +37,8 @@ public class Principal {
                 new Funcionario("Helena",  LocalDate.of(1996, 9, 2),   bd("2799.93"), "Gerente")
         ));
 
+        FuncionarioService service = new FuncionarioService();
+
         // 3.2 – Remover “João”
         funcionarios.removeIf(f -> f.getNome().equalsIgnoreCase("João"));
 
@@ -45,9 +47,7 @@ public class Principal {
         funcionarios.forEach(Principal::imprimirFuncionario);
 
         // 3.4 – Aumento de 10%
-        funcionarios.forEach(f ->
-                f.setSalario(f.getSalario().multiply(bd("1.10")).setScale(2, RoundingMode.HALF_UP))
-        );
+        service.aplicarAumento(funcionarios, bd("10"));
 
         System.out.println("\n==== Após aumento de 10% ====");
         funcionarios.forEach(Principal::imprimirFuncionario);

--- a/PooNoReinoAnimal/src/test/java/br/com/iniflex/FuncionarioServiceTest.java
+++ b/PooNoReinoAnimal/src/test/java/br/com/iniflex/FuncionarioServiceTest.java
@@ -31,7 +31,7 @@ class FuncionarioServiceTest {
     @Test
     void deveAplicarAumentoDe10PorCento() {
         service.removerPorNome(lista, "João");
-        service.aplicarAumento(lista, new BigDecimal("1.10"));
+        service.aplicarAumento(lista, new BigDecimal("10"));
 
         // soma esperada (após remoção do João) = 31.978,18
         BigDecimal esperado = new BigDecimal("31978.18");
@@ -96,7 +96,7 @@ class FuncionarioServiceTest {
     @Test
     void deveCalcularSalariosMinimos() {
         service.removerPorNome(lista, "João");
-        service.aplicarAumento(lista, new BigDecimal("1.10"));
+        service.aplicarAumento(lista, new BigDecimal("10"));
 
         Map<String, BigDecimal> qtd = service.salariosMinimos(lista, new BigDecimal("1212.00"));
         // alguns asserts pontuais (após aumento):


### PR DESCRIPTION
## Summary
- Allow aplicarAumento to receive a percentage and compute its multiplier internally
- Use the updated service in Principal for 10% salary increase
- Adjust tests to call aplicarAumento with percentage values

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68be4d60998c832e96493f3a73a46bf4