### PR TITLE
Centralize Funcionario formatting and simplify output

### DIFF
--- a/PooNoReinoAnimal/src/main/java/br/com/iniflex/Funcionario.java
+++ b/PooNoReinoAnimal/src/main/java/br/com/iniflex/Funcionario.java
@@ -1,11 +1,23 @@
 package br.com.iniflex;
 
 import java.math.BigDecimal;
+import java.text.NumberFormat;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public class Funcionario extends Pessoa {
     private BigDecimal salario;
     private final String funcao;
+
+    private static final Locale PT_BR = new Locale("pt", "BR");
+    private static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private static final NumberFormat NF = NumberFormat.getNumberInstance(PT_BR);
+
+    static {
+        NF.setMinimumFractionDigits(2);
+        NF.setMaximumFractionDigits(2);
+    }
 
     public Funcionario(String nome, LocalDate dataNascimento, BigDecimal salario, String funcao) {
         super(nome, dataNascimento);
@@ -16,4 +28,15 @@ public class Funcionario extends Pessoa {
     public BigDecimal getSalario() { return salario; }
     public void setSalario(BigDecimal salario) { this.salario = salario; }
     public String getFuncao() { return funcao; }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "%s — %s — Nasc.: %s — Salário: %s",
+                getNome(),
+                funcao,
+                getDataNascimento().format(DF),
+                NF.format(salario)
+        );
+    }
 }

--- a/PooNoReinoAnimal/src/main/java/br/com/iniflex/Principal.java
+++ b/PooNoReinoAnimal/src/main/java/br/com/iniflex/Principal.java
@@ -6,14 +6,12 @@ import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.Period;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class Principal {
 
     private static final Locale PT_BR = new Locale("pt", "BR");
-    private static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     private static final NumberFormat NF = NumberFormat.getNumberInstance(PT_BR); // 1.234,56
     private static final BigDecimal SAL_MIN = new BigDecimal("1212.00");
 
@@ -42,7 +40,7 @@ public class Principal {
 
         // 3.3 – Imprimir todos (data dd/MM/aaaa, números 1.234,56)
         System.out.println("==== Funcionários (dados formatados) ====");
-        funcionarios.forEach(Principal::imprimirFuncionario);
+        funcionarios.forEach(System.out::println);
 
         // 3.4 – Aumento de 10%
         funcionarios.forEach(f ->
@@ -50,7 +48,7 @@ public class Principal {
         );
 
         System.out.println("\n==== Após aumento de 10% ====");
-        funcionarios.forEach(Principal::imprimirFuncionario);
+        funcionarios.forEach(System.out::println);
 
         // 3.5 – Agrupar por função
         Map<String, List<Funcionario>> porFuncao = funcionarios.stream()
@@ -60,7 +58,7 @@ public class Principal {
         System.out.println("\n==== Agrupados por função ====");
         porFuncao.forEach((funcao, lista) -> {
             System.out.println("Função: " + funcao);
-            lista.forEach(Principal::imprimirFuncionarioSimples);
+            lista.forEach(System.out::println);
             System.out.println();
         });
 
@@ -71,7 +69,7 @@ public class Principal {
                     int m = f.getDataNascimento().getMonthValue();
                     return (m == Month.OCTOBER.getValue() || m == Month.DECEMBER.getValue());
                 })
-                .forEach(Principal::imprimirFuncionarioSimples);
+                .forEach(System.out::println);
 
         // 3.9 – Funcionário com maior idade (nome e idade)
         Funcionario maisVelho = funcionarios.stream()
@@ -85,7 +83,7 @@ public class Principal {
         System.out.println("\n==== Ordenados por nome (A-Z) ====");
         funcionarios.stream()
                 .sorted(Comparator.comparing(Funcionario::getNome, String.CASE_INSENSITIVE_ORDER))
-                .forEach(Principal::imprimirFuncionarioSimples);
+                .forEach(System.out::println);
 
         // 3.11 – Total dos salários
         BigDecimal totalSalarios = funcionarios.stream()
@@ -104,22 +102,5 @@ public class Principal {
 
     private static BigDecimal bd(String v) { return new BigDecimal(v); }
 
-    private static void imprimirFuncionario(Funcionario f) {
-        String linha = String.format(
-                "%-10s | Nasc.: %s | Salário: %s | Função: %s",
-                f.getNome(),
-                f.getDataNascimento().format(DF),
-                NF.format(f.getSalario()),
-                f.getFuncao()
-        );
-        System.out.println(linha);
-    }
-
-    private static void imprimirFuncionarioSimples(Funcionario f) {
-        System.out.println(
-                f.getNome() + " — " + f.getFuncao() +
-                        " — Nasc.: " + f.getDataNascimento().format(DF) +
-                        " — Salário: " + NF.format(f.getSalario())
-        );
-    }
+    
 }


### PR DESCRIPTION
## Summary
- Add formatted `toString` in `Funcionario` with PT-BR date and salary handling
- Remove redundant printing helpers from `Principal` and use `Funcionario.toString()` directly

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68be4d6b2e58832e8c41cca5ea2790e7