### PR TITLE
Simplify root gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,9 @@
-/meuPrimeiroProgramaJava/out/production/intellij/br/com/dio/primeiroPrograma.class
-/PooNoReinoAnimal/.gitignore
-/PooNoReinoAnimal/.gitattributes
-/meuPrimeiroProgramaJava/intellij.iml
-/meuPrimeiroProgramaJava/meuPrimeiroProgramaJava.iml
-/meuPrimeiroProgramaJava/intellij.iml
-/.idea/compiler.xml
-/.idea/jarRepositories.xml
-/meuPrimeiroProgramaJava/target/classes/br/com/dio/primeiroPrograma.class
-/CriandoUmBancoDigitalComJava/target/classes/com/example/Banco.class
-/CriandoUmBancoDigitalComJava/target/classes/com/example/CartaoDebito.class
-/CriandoUmBancoDigitalComJava/target/test-classes/com/example/CartaoDebitoTest.class
-/CriandoUmBancoDigitalComJava/target/classes/com/example/Cliente.class
-/CriandoUmBancoDigitalComJava/target/classes/com/example/Conta.class
-/CriandoUmBancoDigitalComJava/target/classes/com/example/ContaCorrente.class
-/CriandoUmBancoDigitalComJava/target/classes/com/example/ContaPoupanca.class
-/CriandoUmBancoDigitalComJava/target/classes/com/example/IConta.class
-/CriandoUmBancoDigitalComJava/target/classes/com/example/Main.class
-/java-codex-experience.iml
+# Build outputs
+target/
+
+# IntelliJ IDEA files
+.idea/
+*.iml
+
+# Compiled class files
+*.class


### PR DESCRIPTION
## Summary
- Replace path-specific entries with generic patterns in root `.gitignore`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be4ec823a4832e95fa78c118d058b3