### PR TITLE
Centralize documentation in root README

### DIFF
--- a/PooNoReinoAnimal/Readme.md
+++ b/PooNoReinoAnimal/Readme.md
@@ -1,13 +1,5 @@
-# PooNoReinoAnimal
+# Gestão de Funcionários
 
-Este projeto tem como objetivo aplicar conceitos de Programação Orientada a Objetos (POO) por meio de animais. Serão explorados conceitos como herança, polimorfismo, encapsulamento e abstração para modelar diferentes tipos de animais e suas características. O projeto visa proporcionar uma experiência prática de programação orientada a objetos, utilizando a temática do reino animal como contexto de aprendizado.
+Este módulo contém a implementação das regras de gestão de funcionários utilizadas no teste prático.
 
-## Funcionalidades
-
-- Criação de classes para diferentes tipos de animais
-- Definição de atributos e métodos específicos para cada classe de animal
-- Utilização de herança para compartilhar características comuns entre os animais
-- Aplicação de polimorfismo para tratar diferentes tipos de animais de forma genérica
-- Implementação de métodos abstratos para garantir a implementação em todas as classes derivadas
-
-
+Para documentação completa e instruções de uso, consulte o [README](../README.md) localizado na raiz do projeto.


### PR DESCRIPTION
## Summary
- Retire outdated animal-based description in module README
- Point module README to root guide for employee management

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be4ec0e988832e9e45759bb4ac061c