### PR TITLE
Valida lista vazia em busca de funcionário mais velho

### DIFF
--- a/gestao-funcionarios/src/main/java/br/com/iniflex/FuncionarioService.java
+++ b/gestao-funcionarios/src/main/java/br/com/iniflex/FuncionarioService.java
@@ -44,7 +44,10 @@ public class FuncionarioService {
     }
 
     public Funcionario maisVelho(List<Funcionario> lista) {
-        return lista.stream().min(Comparator.comparing(Funcionario::getDataNascimento)).orElseThrow();
+        if (lista.isEmpty()) {
+            throw new IllegalStateException("Lista de funcionários vazia");
+        }
+        return lista.stream().min(Comparator.comparing(Funcionario::getDataNascimento)).get();
     }
 
     public List<Funcionario> ordenarPorNome(List<Funcionario> lista) {

--- a/gestao-funcionarios/src/test/java/br/com/iniflex/FuncionarioServiceTest.java
+++ b/gestao-funcionarios/src/test/java/br/com/iniflex/FuncionarioServiceTest.java
@@ -77,6 +77,12 @@ class FuncionarioServiceTest {
     }
 
     @Test
+    void deveFalharQuandoListaVazia() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.maisVelho(List.of()));
+        assertEquals("Lista de funcionários vazia", ex.getMessage());
+    }
+
+    @Test
     void deveOrdenarPorNome() {
         service.removerPorNome(lista, "João");
         List<Funcionario> ordenados = service.ordenarPorNome(lista);


### PR DESCRIPTION
## Summary
- valida cenário de lista vazia antes de encontrar funcionário mais velho
- testa exceção para lista sem funcionários

## Testing
- `mvn -q -pl gestao-funcionarios test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be55a42d24832e9380cce8bdf46d67