### PR TITLE
Add null safety for employee printing

### DIFF
--- a/gestao-funcionarios/src/main/java/br/com/iniflex/FuncionarioFormatter.java
+++ b/gestao-funcionarios/src/main/java/br/com/iniflex/FuncionarioFormatter.java
@@ -1,0 +1,50 @@
+package br.com.iniflex;
+
+import java.text.NumberFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class FuncionarioFormatter {
+    private static final Locale PT_BR = new Locale("pt", "BR");
+    private static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private static final NumberFormat NF = NumberFormat.getNumberInstance(PT_BR);
+    public static final String MSG_DADOS_INDISPONIVEIS = "Dados do funcionário incompletos";
+
+    static {
+        NF.setMinimumFractionDigits(2);
+        NF.setMaximumFractionDigits(2);
+    }
+
+    private static void validar(Funcionario f) {
+        if (f == null) {
+            throw new IllegalArgumentException("Funcionario não pode ser nulo");
+        }
+    }
+
+    private static boolean dadosIncompletos(Funcionario f) {
+        return f.getNome() == null || f.getFuncao() == null ||
+                f.getDataNascimento() == null || f.getSalario() == null;
+    }
+
+    public static String formatar(Funcionario f) {
+        validar(f);
+        if (dadosIncompletos(f)) {
+            return MSG_DADOS_INDISPONIVEIS;
+        }
+        return String.format("%-10s | Nasc.: %s | Salário: %s | Função: %s",
+                f.getNome(),
+                f.getDataNascimento().format(DF),
+                NF.format(f.getSalario()),
+                f.getFuncao());
+    }
+
+    public static String formatarSimples(Funcionario f) {
+        validar(f);
+        if (dadosIncompletos(f)) {
+            return MSG_DADOS_INDISPONIVEIS;
+        }
+        return f.getNome() + " — " + f.getFuncao() +
+                " — Nasc.: " + f.getDataNascimento().format(DF) +
+                " — Salário: " + NF.format(f.getSalario());
+    }
+}

--- a/gestao-funcionarios/src/main/java/br/com/iniflex/Principal.java
+++ b/gestao-funcionarios/src/main/java/br/com/iniflex/Principal.java
@@ -5,7 +5,6 @@ import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.Period;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -13,7 +12,6 @@ import java.util.Map;
 public class Principal {
 
     private static final Locale PT_BR = new Locale("pt", "BR");
-    private static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("dd/MM/yyyy");
     private static final NumberFormat NF = NumberFormat.getNumberInstance(PT_BR); // 1.234,56
     private static final BigDecimal SAL_MIN = new BigDecimal("1212.00");
     private static final BigDecimal FATOR_AUMENTO = new BigDecimal("1.10");
@@ -68,21 +66,10 @@ public class Principal {
     }
 
     private static void imprimirFuncionario(Funcionario f) {
-        String linha = String.format(
-                "%-10s | Nasc.: %s | Salário: %s | Função: %s",
-                f.getNome(),
-                f.getDataNascimento().format(DF),
-                NF.format(f.getSalario()),
-                f.getFuncao()
-        );
-        System.out.println(linha);
+        System.out.println(FuncionarioFormatter.formatar(f));
     }
 
     private static void imprimirFuncionarioSimples(Funcionario f) {
-        System.out.println(
-                f.getNome() + " — " + f.getFuncao() +
-                        " — Nasc.: " + f.getDataNascimento().format(DF) +
-                        " — Salário: " + NF.format(f.getSalario())
-        );
+        System.out.println(FuncionarioFormatter.formatarSimples(f));
     }
 }

--- a/gestao-funcionarios/src/test/java/br/com/iniflex/FuncionarioFormatterTest.java
+++ b/gestao-funcionarios/src/test/java/br/com/iniflex/FuncionarioFormatterTest.java
@@ -1,0 +1,26 @@
+package br.com.iniflex;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FuncionarioFormatterTest {
+
+    @Test
+    void deveLancarExcecaoQuandoFuncionarioForNulo() {
+        assertThrows(IllegalArgumentException.class, () -> FuncionarioFormatter.formatar(null));
+        assertThrows(IllegalArgumentException.class, () -> FuncionarioFormatter.formatarSimples(null));
+    }
+
+    @Test
+    void deveRetornarMensagemPadraoQuandoCampoEssencialForNulo() {
+        Funcionario f = new Funcionario(null, LocalDate.now(), new BigDecimal("1000.00"), "Tester");
+        String completo = FuncionarioFormatter.formatar(f);
+        String simples = FuncionarioFormatter.formatarSimples(f);
+        assertEquals(FuncionarioFormatter.MSG_DADOS_INDISPONIVEIS, completo);
+        assertEquals(FuncionarioFormatter.MSG_DADOS_INDISPONIVEIS, simples);
+    }
+}


### PR DESCRIPTION
## Summary
- Validate employee and essential fields before formatting
- Provide default message when required data is missing
- Test formatter handling of null employees and fields

## Testing
- `mvn -q -pl gestao-funcionarios test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be55b868ac832e97df301c4ad089b5