### PR TITLE
Handle empty birthday month list in Principal

### DIFF
--- a/gestao-funcionarios/src/main/java/br/com/iniflex/Principal.java
+++ b/gestao-funcionarios/src/main/java/br/com/iniflex/Principal.java
@@ -51,8 +51,12 @@ public class Principal {
             });
 
             System.out.println("==== Aniversários em OUT (10) e DEZ (12) ====");
-            service.aniversariantesMeses(funcionarios, Month.OCTOBER, Month.DECEMBER)
-                    .forEach(Principal::imprimirFuncionarioSimples);
+            List<Funcionario> aniversariantes = service.aniversariantesMeses(funcionarios, Month.OCTOBER, Month.DECEMBER);
+            if (aniversariantes.isEmpty()) {
+                System.out.println("Nenhum funcionário faz aniversário nos meses informados");
+            } else {
+                aniversariantes.forEach(Principal::imprimirFuncionarioSimples);
+            }
 
             Funcionario maisVelho = service.maisVelho(funcionarios);
             int idade = Period.between(maisVelho.getDataNascimento(), LocalDate.now()).getYears();


### PR DESCRIPTION
## Summary
- Store birthday-month filter results in a temporary list
- Print a message when no employees match the selected months

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be5dc49b3c832ea8e882be21034296