### PR TITLE
feat: display list before removal and confirm deletions

### DIFF
--- a/gestao-funcionarios/src/main/java/br/com/iniflex/FuncionarioService.java
+++ b/gestao-funcionarios/src/main/java/br/com/iniflex/FuncionarioService.java
@@ -24,12 +24,12 @@ public class FuncionarioService {
         ));
     }
 
-    public void removerPorNome(List<Funcionario> lista, String nome) {
+    public boolean removerPorNome(List<Funcionario> lista, String nome) {
         validarLista(lista);
         if (nome == null || nome.isBlank()) {
             throw new IllegalArgumentException("nome inválido");
         }
-        lista.removeIf(f -> f.getNome().equalsIgnoreCase(nome));
+        return lista.removeIf(f -> f.getNome().equalsIgnoreCase(nome));
     }
 
     public void aplicarAumento(List<Funcionario> lista, BigDecimal fator) {

--- a/gestao-funcionarios/src/main/java/br/com/iniflex/Principal.java
+++ b/gestao-funcionarios/src/main/java/br/com/iniflex/Principal.java
@@ -31,10 +31,15 @@ public class Principal {
         try {
             List<Funcionario> funcionarios = service.seed();
 
-            service.removerPorNome(funcionarios, "João");
-
             System.out.println("==== Funcionários (dados formatados) ====");
             funcionarios.forEach(Principal::imprimirFuncionario);
+
+            boolean removido = service.removerPorNome(funcionarios, "João");
+            if (removido) {
+                System.out.println("\nFuncionário removido com sucesso.");
+            } else {
+                System.out.println("\nNome não encontrado.");
+            }
 
             service.aplicarAumento(funcionarios, FATOR_AUMENTO);
 

--- a/gestao-funcionarios/src/test/java/br/com/iniflex/FuncionarioServiceTest.java
+++ b/gestao-funcionarios/src/test/java/br/com/iniflex/FuncionarioServiceTest.java
@@ -23,9 +23,17 @@ class FuncionarioServiceTest {
 
     @Test
     void deveRemoverJoaoDaLista() {
-        service.removerPorNome(lista, "João");
+        boolean removido = service.removerPorNome(lista, "João");
+        assertTrue(removido);
         assertEquals(9, lista.size());
         assertTrue(lista.stream().noneMatch(f -> f.getNome().equalsIgnoreCase("João")));
+    }
+
+    @Test
+    void deveRetornarFalseQuandoNomeNaoEncontrado() {
+        boolean removido = service.removerPorNome(lista, "Fulano");
+        assertFalse(removido);
+        assertEquals(10, lista.size());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- print employees right after seeding and before removals
- return removal status from `removerPorNome`
- log success or missing name after attempting removal

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be5dbcd65c832eae9125f0899fb003